### PR TITLE
Restructure dirs and improve dir creation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,8 @@ While tilde is meant to be very hands off, there's still a few things you'll nee
 
 If you don't have ssh keys set up, please take a look at the [Github Docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) on the topic.
 
-NOTE: This is for your personal machine, NOT for the server. 
 
 Your ssh config should should look something like this if you're on MacOS:
-
 
 ```
 # .ssh/config
@@ -75,8 +73,9 @@ host *
   UseKeychain yes
   IdentityFile ~/.ssh/id_ed25519
 ```
-
 > Replace \<homeserver\>, \<internal-ip-of-server\>, and \<non-root-user\> with the appropriate values (without the < >)
+
+NOTE: This is for your personal machine, NOT for the server. 
 
 If you're on a different OS, the guide has instructions for windows and linux as well, I trust that you'll be able to follow them :)
 
@@ -130,10 +129,6 @@ WG_HOST=<record_name.your_domain.com>
 ```
 > Without the < >
 
-There are a few other values in the [.env](./tilde/compose/.env) file but you can leave those alone, they'll be fixed up by the [run script](./run.sh). 
-
-Or you can change them, it's up to you!
-
 ### ❖ Deploying.
 
 Phew that was a lot!! But we're finally ready to deploy!
@@ -160,7 +155,7 @@ If everything goes as expected, you'll have a shiny new homeserver complete with
 
 ### ❖ What's New? 
 
-0.1.1 - Minor dependency changes
+0.1.2 - Changes to directory structure and directory creation logic
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tilde"
-version = "0.1.1"
+version = "0.1.2"
 description = "An automatic homeserver deployment, forever a work in progress"
 authors = ["dotzenith"]
 license = "MIT"

--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,5 @@
 export SERVER_USER=
 export HOMESERVER=
 
-# Fix Docker Volume Path
-sed -i "" "s/username/$SERVER_USER/g" ./tilde/compose/.env
-
 # Run
 cd tilde && pyinfra inventory.py deploy.py

--- a/tilde/compose/.env
+++ b/tilde/compose/.env
@@ -1,8 +1,3 @@
 POSTGRES_PASSWORD=
 WG_PASS=
 WG_HOST=
-WG_DIR=/home/username/tilde/wireguard/
-JELLYFIN_CONFIG=/home/username/tilde/jellyfin/config
-JELLYFIN_TV=/home/username/tilde/jellyfin/tv
-JELLYFIN_MOVIES=/home/username/tilde/jellyfin/movies
-JELLYFIN_MUSIC=/home/username/tilde/jellyfin/music

--- a/tilde/deploy.py
+++ b/tilde/deploy.py
@@ -10,22 +10,22 @@ _use_sudo_password = True
 
 # Update Apt
 apt.update(
-    name="Update apt repositories", #type: ignore
-    _sudo=True, #type: ignore
+    name="Update apt repositories",  # type: ignore
+    _sudo=True,  # type: ignore
 )
 
 # Add some crucial packages
 apt.packages(
-    name="Install crucial packages", #type: ignore
+    name="Install crucial packages",  # type: ignore
     packages=["sudo", "curl", "git"],
-    _sudo=True, #type: ignore
+    _sudo=True,  # type: ignore
 )
 
 # Installing frequently used packages
 apt.packages(
-    name="Install frequently used packages", #type: ignore
+    name="Install frequently used packages",  # type: ignore
     packages=["vim", "neofetch"],
-    _sudo=True, #type: ignore
+    _sudo=True,  # type: ignore
 )
 
 

--- a/tilde/deploy.py
+++ b/tilde/deploy.py
@@ -3,50 +3,43 @@ The parent deploy script for pyinfra
 """
 
 from pyinfra import local
-from pyinfra.operations import apt, server
-
-from tilde.helpers import USERNAME
+from pyinfra.operations import apt
 
 # Prompt for sudo password when starting
 _use_sudo_password = True
 
 # Update Apt
 apt.update(
-    name="Update apt repositories",
-    _sudo=True,
+    name="Update apt repositories", #type: ignore
+    _sudo=True, #type: ignore
 )
 
 # Add some crucial packages
 apt.packages(
-    name="Install crucial packages",
+    name="Install crucial packages", #type: ignore
     packages=["sudo", "curl", "git"],
-    _sudo=True,
+    _sudo=True, #type: ignore
 )
 
 # Installing frequently used packages
 apt.packages(
-    name="Install frequently used packages",
+    name="Install frequently used packages", #type: ignore
     packages=["vim", "neofetch"],
-    _sudo=True,
+    _sudo=True, #type: ignore
 )
 
-# Make tilde dir
-server.shell(
-    name="Make tilde dir",
-    commands=[
-        f"if [ ! -d /home/{USERNAME}/tilde ]; \
-                then mkdir /home/{USERNAME}/tilde; fi",
-    ],
-)
+
+# Set up some directories
+local.include("tasks/make_dirs.py")
+
+# Sync Files
+local.include("tasks/sync_files.py")
 
 # Install Docker
 local.include("tasks/install_docker.py")
 
 # Deploy Portainer
 local.include("tasks/deploy_portainer.py")
-
-# Sync Files
-local.include("tasks/sync_files.py")
 
 # Deploy Wireguard
 local.include("tasks/deploy_wireguard.py")

--- a/tilde/tasks/deploy_jellyfin.py
+++ b/tilde/tasks/deploy_jellyfin.py
@@ -6,34 +6,44 @@ Creates directories for Jellffin data and uses a docker-compose file to spin up 
 
 from pyinfra import logger
 from pyinfra.operations import server
+from pyinfra.operations import files
 
-from tilde.helpers import USERNAME, get_docker_env_vars, is_container_running
-
-env_vars = get_docker_env_vars()
+from tilde.helpers import USERNAME, is_container_running
 
 # Spin up stack
 if is_container_running("jellyfin"):
     logger.info("jellyfin container already running")
 else:
     # Make directories for jellyfin files
-    server.shell(
-        name="Make directories for Jellyfin",
-        commands=[
-            f"if [ ! -d {env_vars['JELLYFIN_CONFIG']} ]; \
-                    then mkdir -p {env_vars['JELLYFIN_CONFIG']}; fi",
-            f"if [ ! -d {env_vars['JELLYFIN_TV']} ]; \
-                    then mkdir -p {env_vars['JELLYFIN_TV']}; fi",
-            f"if [ ! -d {env_vars['JELLYFIN_MOVIES']} ]; \
-                    then mkdir -p {env_vars['JELLYFIN_MOVIES']}; fi",
-            f"if [ ! -d {env_vars['JELLYFIN_MUSIC']} ]; \
-                    then mkdir -p {env_vars['JELLYFIN_MUSIC']}; fi",
-        ],
+    files.directory(
+        name = "Make jellyfin config directory", # type: ignore
+        path = "/home/{USERNAME}/data/jellyfin/config",
+        present = True,
+        user = USERNAME,
+    )
+    files.directory(
+        name = "Make jellyfin movies directory", # type: ignore
+        path = "/home/{USERNAME}/data/jellyfin/movies",
+        present = True,
+        user = USERNAME,
+    )
+    files.directory(
+        name = "Make jellyfin tv directory", # type: ignore
+        path = "/home/{USERNAME}/data/jellyfin/tv",
+        present = True,
+        user = USERNAME,
+    )
+    files.directory(
+        name = "Make jellyfin music directory", # type: ignore
+        path = "/home/{USERNAME}/data/jellyfin/music",
+        present = True,
+        user = USERNAME,
     )
     server.shell(
-        name="Deploy Jellyfin container",
+        name="Deploy Jellyfin container", # type: ignore
         commands=[
             f"docker compose -f /home/{USERNAME}/tilde/compose/jellyfin.yml \
               --env-file /home/{USERNAME}/tilde/compose/.env up -d"
         ],
-        _sudo=True,
+        _sudo=True, # type: ignore
     )

--- a/tilde/tasks/deploy_jellyfin.py
+++ b/tilde/tasks/deploy_jellyfin.py
@@ -17,27 +17,29 @@ else:
     # Make directories for jellyfin files
     files.directory(
         name = "Make jellyfin config directory", # type: ignore
-        path = "/home/{USERNAME}/data/jellyfin/config",
+        path = f"/home/{USERNAME}/data/jellyfin/config",
         present = True,
         user = USERNAME,
     )
     files.directory(
         name = "Make jellyfin movies directory", # type: ignore
-        path = "/home/{USERNAME}/data/jellyfin/movies",
+        path = f"/home/{USERNAME}/data/jellyfin/movies",
         present = True,
         user = USERNAME,
     )
     files.directory(
         name = "Make jellyfin tv directory", # type: ignore
-        path = "/home/{USERNAME}/data/jellyfin/tv",
+        path = f"/home/{USERNAME}/data/jellyfin/tv",
         present = True,
         user = USERNAME,
+        _sudo = True, #type: ignore
     )
     files.directory(
         name = "Make jellyfin music directory", # type: ignore
-        path = "/home/{USERNAME}/data/jellyfin/music",
+        path = f"/home/{USERNAME}/data/jellyfin/music",
         present = True,
         user = USERNAME,
+        _sudo = True, #type: ignore
     )
     server.shell(
         name="Deploy Jellyfin container", # type: ignore

--- a/tilde/tasks/deploy_jellyfin.py
+++ b/tilde/tasks/deploy_jellyfin.py
@@ -5,8 +5,7 @@ Creates directories for Jellffin data and uses a docker-compose file to spin up 
 """
 
 from pyinfra import logger
-from pyinfra.operations import server
-from pyinfra.operations import files
+from pyinfra.operations import files, server
 
 from tilde.helpers import USERNAME, is_container_running
 
@@ -16,36 +15,36 @@ if is_container_running("jellyfin"):
 else:
     # Make directories for jellyfin files
     files.directory(
-        name = "Make jellyfin config directory", # type: ignore
-        path = f"/home/{USERNAME}/data/jellyfin/config",
-        present = True,
-        user = USERNAME,
+        name="Make jellyfin config directory",  # type: ignore
+        path=f"/home/{USERNAME}/data/jellyfin/config",
+        present=True,
+        user=USERNAME,
     )
     files.directory(
-        name = "Make jellyfin movies directory", # type: ignore
-        path = f"/home/{USERNAME}/data/jellyfin/movies",
-        present = True,
-        user = USERNAME,
+        name="Make jellyfin movies directory",  # type: ignore
+        path=f"/home/{USERNAME}/data/jellyfin/movies",
+        present=True,
+        user=USERNAME,
     )
     files.directory(
-        name = "Make jellyfin tv directory", # type: ignore
-        path = f"/home/{USERNAME}/data/jellyfin/tv",
-        present = True,
-        user = USERNAME,
-        _sudo = True, #type: ignore
+        name="Make jellyfin tv directory",  # type: ignore
+        path=f"/home/{USERNAME}/data/jellyfin/tv",
+        present=True,
+        user=USERNAME,
+        _sudo=True,  # type: ignore
     )
     files.directory(
-        name = "Make jellyfin music directory", # type: ignore
-        path = f"/home/{USERNAME}/data/jellyfin/music",
-        present = True,
-        user = USERNAME,
-        _sudo = True, #type: ignore
+        name="Make jellyfin music directory",  # type: ignore
+        path=f"/home/{USERNAME}/data/jellyfin/music",
+        present=True,
+        user=USERNAME,
+        _sudo=True,  # type: ignore
     )
     server.shell(
-        name="Deploy Jellyfin container", # type: ignore
+        name="Deploy Jellyfin container",  # type: ignore
         commands=[
             f"docker compose -f /home/{USERNAME}/tilde/compose/jellyfin.yml \
               --env-file /home/{USERNAME}/tilde/compose/.env up -d"
         ],
-        _sudo=True, # type: ignore
+        _sudo=True,  # type: ignore
     )

--- a/tilde/tasks/deploy_nextcloud.py
+++ b/tilde/tasks/deploy_nextcloud.py
@@ -17,10 +17,10 @@ if is_container_running("nextcloud"):
 else:
 
     server.shell(
-        name="Deploy Nextcloud container", #type: ignore
+        name="Deploy Nextcloud container",  # type: ignore
         commands=[
             f"docker compose -f /home/{USERNAME}/tilde/compose/nextcloud.yml \
               --env-file /home/{USERNAME}/tilde/compose/.env up -d"
         ],
-        _sudo=True, #type: ignore
+        _sudo=True,  # type: ignore
     )

--- a/tilde/tasks/deploy_nextcloud.py
+++ b/tilde/tasks/deploy_nextcloud.py
@@ -17,10 +17,10 @@ if is_container_running("nextcloud"):
 else:
 
     server.shell(
-        name="Deploy Nextcloud container",
+        name="Deploy Nextcloud container", #type: ignore
         commands=[
             f"docker compose -f /home/{USERNAME}/tilde/compose/nextcloud.yml \
               --env-file /home/{USERNAME}/tilde/compose/.env up -d"
         ],
-        _sudo=True,
+        _sudo=True, #type: ignore
     )

--- a/tilde/tasks/deploy_portainer.py
+++ b/tilde/tasks/deploy_portainer.py
@@ -13,7 +13,7 @@ if is_container_running("portainer"):
     logger.info("Portainer Already running")
 else:
     server.shell(
-        name="Deploy Portainer",
+        name="Deploy Portainer", #type: ignore
         commands=[
             "docker volume create portainer_data",
             "docker run -d -p 8000:8000 -p 9443:9443 -p 9000:9000 --name portainer \
@@ -22,5 +22,5 @@ else:
             -v portainer_data:/data \
             portainer/portainer-ce:2.9.3",
         ],
-        _sudo=True,
+        _sudo=True, #type: ignore
     )

--- a/tilde/tasks/deploy_portainer.py
+++ b/tilde/tasks/deploy_portainer.py
@@ -13,7 +13,7 @@ if is_container_running("portainer"):
     logger.info("Portainer Already running")
 else:
     server.shell(
-        name="Deploy Portainer", #type: ignore
+        name="Deploy Portainer",  # type: ignore
         commands=[
             "docker volume create portainer_data",
             "docker run -d -p 8000:8000 -p 9443:9443 -p 9000:9000 --name portainer \
@@ -22,5 +22,5 @@ else:
             -v portainer_data:/data \
             portainer/portainer-ce:2.9.3",
         ],
-        _sudo=True, #type: ignore
+        _sudo=True,  # type: ignore
     )

--- a/tilde/tasks/deploy_wireguard.py
+++ b/tilde/tasks/deploy_wireguard.py
@@ -6,9 +6,10 @@ It first runs an update script for Dynamic DNS and then sets up a cron job to ru
 It then uses a docker-compose file to spin up the stack
 """
 from pyinfra import host, logger
-from pyinfra.operations import server, files
+from pyinfra.operations import files, server
 
 from tilde.helpers import USERNAME, is_container_running
+
 
 # Helper function
 def is_cron_job_initiated(cron_file: str):
@@ -28,9 +29,9 @@ def is_cron_job_initiated(cron_file: str):
 
 # Update cloudflare dns
 server.shell(
-    name="Run DDNS script", #type: ignore
+    name="Run DDNS script",  # type: ignore
     commands=[f"bash /home/{USERNAME}/tilde/templates/cloudflare-template.sh"],
-    _sudo=True, #type: ignore
+    _sudo=True,  # type: ignore
 )
 
 # Add cron job
@@ -38,12 +39,12 @@ if is_cron_job_initiated("cloudflare_job"):
     logger.info("Cloudflare job already set up")
 else:
     server.shell(
-        name="Add DDNS script to cron", #type: ignore
+        name="Add DDNS script to cron",  # type: ignore
         commands=[
             f"echo '0 0 * * * /home/{USERNAME}/tilde/templates/cloudflare-template.sh' > cloudflare_job",
             "mv cloudflare_job /etc/cron.d/",
         ],
-        _sudo=True, #type: ignore
+        _sudo=True,  # type: ignore
     )
 
 # Spin up stack
@@ -51,16 +52,16 @@ if is_container_running("wireguard"):
     logger.info("Wireguard container already running")
 else:
     files.directory(
-        name = "Make directory for Wireguard", #type: ignore
-        path = f"/home/{USERNAME}/data/wireguard",
-        user = USERNAME,
-        present = True,
+        name="Make directory for Wireguard",  # type: ignore
+        path=f"/home/{USERNAME}/data/wireguard",
+        user=USERNAME,
+        present=True,
     )
     server.shell(
-        name="Deploy Wireguard container", #type: ignore
+        name="Deploy Wireguard container",  # type: ignore
         commands=[
             f"docker compose -f /home/{USERNAME}/tilde/compose/wireguard.yml \
               --env-file /home/{USERNAME}/tilde/compose/.env up -d"
         ],
-        _sudo=True, #type: ignore
+        _sudo=True,  # type: ignore
     )

--- a/tilde/tasks/deploy_wireguard.py
+++ b/tilde/tasks/deploy_wireguard.py
@@ -52,7 +52,7 @@ if is_container_running("wireguard"):
 else:
     files.directory(
         name = "Make directory for Wireguard", #type: ignore
-        path = "/home/{USERNAME}/data/wireguard",
+        path = f"/home/{USERNAME}/data/wireguard",
         user = USERNAME,
         present = True,
     )

--- a/tilde/tasks/install_docker.py
+++ b/tilde/tasks/install_docker.py
@@ -27,20 +27,20 @@ if is_docker_installed():
     logger.info("Docker Already Installed")
 else:
     server.shell(
-        name="Install docker", #type: ignore
+        name="Install docker",  # type: ignore
         commands=[
             "curl -fsSL https://get.docker.com -o get-docker.sh",
             "sh get-docker.sh",
             "systemctl enable docker",
         ],
-        _sudo=True, #type: ignore 
+        _sudo=True,  # type: ignore
     )
 
     server.shell(
-        name=f"Create docker group and add {USERNAME} to group", #type: ignore
+        name=f"Create docker group and add {USERNAME} to group",  # type: ignore
         commands=[
             "getent group somegroupname || groupadd somegroupname",
             f"usermod -aG docker {USERNAME}",
         ],
-        _sudo=True, #type: ignore
+        _sudo=True,  # type: ignore
     )

--- a/tilde/tasks/install_docker.py
+++ b/tilde/tasks/install_docker.py
@@ -27,20 +27,20 @@ if is_docker_installed():
     logger.info("Docker Already Installed")
 else:
     server.shell(
-        name="Install docker",
+        name="Install docker", #type: ignore
         commands=[
             "curl -fsSL https://get.docker.com -o get-docker.sh",
             "sh get-docker.sh",
             "systemctl enable docker",
         ],
-        _sudo=True,
+        _sudo=True, #type: ignore 
     )
 
     server.shell(
-        name=f"Create docker group and add {USERNAME} to group",
+        name=f"Create docker group and add {USERNAME} to group", #type: ignore
         commands=[
             "getent group somegroupname || groupadd somegroupname",
             f"usermod -aG docker {USERNAME}",
         ],
-        _sudo=True,
+        _sudo=True, #type: ignore
     )

--- a/tilde/tasks/make_dirs.py
+++ b/tilde/tasks/make_dirs.py
@@ -1,0 +1,21 @@
+"""
+A task to sync the templates and docker-compose files
+"""
+
+from pyinfra.operations import files
+
+from tilde.helpers import USERNAME
+
+files.directory(
+    name = "Ensure a directory exists for all of the tilde files", #type: ignore
+    path = f"/home/{USERNAME}/tilde",
+    user = USERNAME,
+    present = True,
+)
+
+files.directory(
+    name = "Ensure a directory exists to store data for various services", #type: ignore
+    path = f"/home/{USERNAME}/data",
+    user = USERNAME,
+    present = True,
+)

--- a/tilde/tasks/make_dirs.py
+++ b/tilde/tasks/make_dirs.py
@@ -7,15 +7,15 @@ from pyinfra.operations import files
 from tilde.helpers import USERNAME
 
 files.directory(
-    name = "Ensure a directory exists for all of the tilde files", #type: ignore
-    path = f"/home/{USERNAME}/tilde",
-    user = USERNAME,
-    present = True,
+    name="Ensure a directory exists for all of the tilde files",  # type: ignore
+    path=f"/home/{USERNAME}/tilde",
+    user=USERNAME,
+    present=True,
 )
 
 files.directory(
-    name = "Ensure a directory exists to store data for various services", #type: ignore
-    path = f"/home/{USERNAME}/data",
-    user = USERNAME,
-    present = True,
+    name="Ensure a directory exists to store data for various services",  # type: ignore
+    path=f"/home/{USERNAME}/data",
+    user=USERNAME,
+    present=True,
 )

--- a/tilde/tasks/sync_files.py
+++ b/tilde/tasks/sync_files.py
@@ -8,7 +8,7 @@ from tilde.helpers import USERNAME
 
 # Sync templates
 files.sync(
-    name="Sync templates", #type: ignore
+    name="Sync templates",  # type: ignore
     user=USERNAME,
     src="templates",
     dest=f"/home/{USERNAME}/tilde/templates/",
@@ -16,7 +16,7 @@ files.sync(
 
 # Sync compose files
 files.sync(
-    name="Sync compose files", # type: ignore
+    name="Sync compose files",  # type: ignore
     user=USERNAME,
     src="compose",
     dest=f"/home/{USERNAME}/tilde/compose/",

--- a/tilde/tasks/sync_files.py
+++ b/tilde/tasks/sync_files.py
@@ -8,7 +8,7 @@ from tilde.helpers import USERNAME
 
 # Sync templates
 files.sync(
-    name="Sync templates",
+    name="Sync templates", #type: ignore
     user=USERNAME,
     src="templates",
     dest=f"/home/{USERNAME}/tilde/templates/",
@@ -16,7 +16,7 @@ files.sync(
 
 # Sync compose files
 files.sync(
-    name="Sync compose files",
+    name="Sync compose files", # type: ignore
     user=USERNAME,
     src="compose",
     dest=f"/home/{USERNAME}/tilde/compose/",


### PR DESCRIPTION
There are a few issues with the current approach towards creating directories on the server and storing data in them. 

The issues are as follows:

- All files used by tilde, and directories used by the services are under `$HOME/tilde`, this should be changed. Tilde files should live in their own directory and directories used by the services should live in their own. 
- The current way of creating directories for services like `jellyfin` and `wireguard` rely too heavily on shell commands. Wherever possible, operations native to `pyinfra` should be used for such tasks. 

This PR implements solutions to the problems above in the following ways: 

- There are now two directories created on the server. `$HOME/tilde` and `$HOME/data`. The earlier will contain all of the files used by tilde while the latter will contain paths to be mounted in `docker-compose` files for all of the services. The latter should be used for all future services as well. 
- The `jellyfin` and `wireguard` tasks no longer rely on shell commands for directory creation and no longer uses environment variables declared in `compose/.env`. If a user wants to change the paths, they are free to change the tasks themselves. 